### PR TITLE
Fix not in client v2

### DIFF
--- a/lib/atom-perforce.js
+++ b/lib/atom-perforce.js
@@ -152,7 +152,7 @@ atomPerforce.exports = {
             // call p4 info to make sure perforce is available
             return execP4Command('info', { cwd: openedBufferFilePath })
             .then(function(p4Info) {
-                if(!p4Info['clientUnknown.'] && openedBufferFilePath.startsWith(p4Info.clientRoot)) {
+                if(!p4Info['clientUnknown.'] && p4Info.currentDirectory.startsWith(p4Info.clientRoot)) {
                     return execP4Command('edit', { cwd: openedBufferFilePath, files: [openedBufferFilename] })
                     .then(function(result) {
                         // p4 edit returns a 0 exit code even if the file is already opened
@@ -201,7 +201,7 @@ atomPerforce.exports = {
             // call p4 info to make sure perforce is available
             return execP4Command('info', { cwd: openedBufferFilePath })
             .then(function(p4Info) {
-                if(!p4Info['clientUnknown.'] && openedBufferFilePath.startsWith(p4Info.clientRoot)) {
+                if(!p4Info['clientUnknown.'] && p4Info.currentDirectory.startsWith(p4Info.clientRoot)) {
                     return execP4Command('add', { cwd: openedBufferFilePath, files: [openedBufferFilename] })
                     .then(function(result) {
                         // for some unfortunate reason, p4 add <existing file> returns a 0 exit code
@@ -305,7 +305,7 @@ atomPerforce.exports = {
                 // call p4 info to make sure perforce is available
                 execP4Command('info', { cwd: dir })
                 .then(function(p4Info) {
-                    if (!p4Info['clientUnknown.'] && dir.startsWith(p4Info.clientRoot)) {
+                    if (!p4Info['clientUnknown.'] && p4Info.currentDirectory.startsWith(p4Info.clientRoot)) {
                         return execP4Command('sync', { cwd: dir, files: ['./...'] });
                     }
                 })
@@ -364,7 +364,7 @@ atomPerforce.exports = {
             // call p4 info to make sure perforce is available
             return execP4Command('info', { cwd: filepath })
             .then(function(p4Info) {
-                if (!p4Info['clientUnknown.'] && filepath.startsWith(p4Info.clientRoot)) {
+                if (!p4Info['clientUnknown.'] && p4Info.currentDirectory.startsWith(p4Info.clientRoot)) {
                     return execP4Command('revert', {
                         cwd: filepath,
                         files: [path.basename(filename)]
@@ -436,7 +436,7 @@ atomPerforce.exports = {
             // call p4 info to make sure perforce is available
             execP4Command('info', { cwd: openedBufferFilePath })
             .then(function(p4Info) {
-                if (!p4Info['clientUnknown.'] && openedBufferFilePath.startsWith(p4Info.clientRoot)) {
+                if (!p4Info['clientUnknown.'] && p4Info.currentDirectory.startsWith(p4Info.clientRoot)) {
                                     // call p4 diff on the file
                     return execP4Command('diff', {
                         cwd: openedBufferFilePath,
@@ -534,7 +534,7 @@ atomPerforce.exports = {
             // call p4 info to make sure perforce is available
             execP4Command('info', { cwd: dir })
             .then(function(p4Info) {
-                if(p4Info['clientUnknown.'] || dir.startsWith(p4Info.clientRoot)) {
+                if(p4Info['clientUnknown.'] || p4Info.currentDirectory.startsWith(p4Info.clientRoot)) {
                     setStatusClient(false);
                 }
                 else {
@@ -701,10 +701,10 @@ atomPerforce.exports = {
     fileIsTracked: function fileIsTracked(filepath) {
         var deferred = Q.defer();
         var dir = path.dirname(filepath);
-        
+
         execP4Command('info', { cwd: dir })
         .then(function(p4Info) {
-            if (!p4Info['clientUnknown.'] && dir.startsWith(p4Info.clientRoot)) {            
+            if (!p4Info['clientUnknown.'] && p4Info.currentDirectory.startsWith(p4Info.clientRoot)) {            
                 return execP4Command('fstat', {
                     cwd: dir,
                     files: [path.basename(filepath)]


### PR DESCRIPTION
Because original path could have upper case drive letter instead of
lower case. So the startsWith will file as the clientRoot uses lower
case.
